### PR TITLE
Add meta, social, and iconography elements

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Scryfall Art Game</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="og:title" content="Scryfall Art Game">
+  <meta name="og:type" content="website">
+  <meta name="og:image" content="https://assets.scryfall.com/icon.png?v=cb2efa3b7334b4428ab13c6f85673510">
+  <meta name="og:url" content="https://artgame.scryfall.com/">
+  <meta name="og:site_name" content="Scryfall">
+  <meta name="og:description" content="Guess Magic: the Gathering cards from their art">
+  <meta name="description" content="Guess Magic: the Gathering cards from their art">
+  <link rel="icon" type="image/x-icon" href="https://assets.scryfall.com/favicon.ico?v=cb2efa3b7334b4428ab13c6f85673510">
+  <meta name="apple-mobile-web-app-title" content="Art Game">
+  <link rel="apple-touch-icon" href="https://assets.scryfall.com/apple-touch-icon.png?v=cb2efa3b7334b4428ab13c6f85673510">
+  <link rel="icon" sizes="196x196" href="https://assets.scryfall.com/icon.png?v=cb2efa3b7334b4428ab13c6f85673510">
   <link rel="stylesheet" media="screen" href="css/main.css">
 </head>
 <body>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
   <meta name="og:image" content="https://assets.scryfall.com/icon.png?v=cb2efa3b7334b4428ab13c6f85673510">
   <meta name="og:url" content="https://artgame.scryfall.com/">
   <meta name="og:site_name" content="Scryfall">
-  <meta name="og:description" content="Guess Magic: the Gathering cards from their art">
+  <meta name="og:description" content="Guess Magic: the Gathering cards using only the artwork">
   <meta name="description" content="Guess Magic: the Gathering cards from their art">
   <link rel="icon" type="image/x-icon" href="https://assets.scryfall.com/favicon.ico?v=cb2efa3b7334b4428ab13c6f85673510">
   <meta name="apple-mobile-web-app-title" content="Art Game">

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <meta name="og:url" content="https://artgame.scryfall.com/">
   <meta name="og:site_name" content="Scryfall">
   <meta name="og:description" content="Guess Magic: the Gathering cards using only the artwork">
-  <meta name="description" content="Guess Magic: the Gathering cards from their art">
+  <meta name="description" content="Guess Magic: the Gathering cards using only the artwork">
   <link rel="icon" type="image/x-icon" href="https://assets.scryfall.com/favicon.ico?v=cb2efa3b7334b4428ab13c6f85673510">
   <meta name="apple-mobile-web-app-title" content="Art Game">
   <link rel="apple-touch-icon" href="https://assets.scryfall.com/apple-touch-icon.png?v=cb2efa3b7334b4428ab13c6f85673510">


### PR DESCRIPTION
This adds meta information brought up in #5 and #6. I've also added an `og:image` pointing to the Scryfall icon.

Do you have any preferences on the OG name and description chosen?

I'm opening this as a pull request to make it easier to bring up those changes directly (e.g. with Github's suggestions feature).