### PR TITLE
Make package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "scryfall-art-game",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "index.js",
   "author": "spacemonaut",
   "license": "UNLICENSED",


### PR DESCRIPTION
Prevents accidental publishing of the repo as an npm module.