### PR TITLE
Wrap custom query in brackets

### DIFF
--- a/src/components/PickModeScreen.vue
+++ b/src/components/PickModeScreen.vue
@@ -45,7 +45,7 @@ const presets = [
 
 const customQuery = ref("");
 const customQueryFull = computed(() => {
-  return flatten([customQuery.value, ...commonCriteria]);
+  return flatten([`(${customQuery.value})`, ...commonCriteria]);
 });
 
 const disabled = computed(() => {


### PR DESCRIPTION
Currently if you write your custom query with `or`'s in it, all our common criteria will only apply to the endmost part. You can even write `t:basic or` for a custom query. This patches that up by wrapping the custom query in brackets.