### PR TITLE
Zero out game state with new game

### DIFF
--- a/src/store/game.ts
+++ b/src/store/game.ts
@@ -58,6 +58,10 @@ export const gameSlice = createSlice({
     builder.addCase(startGame.pending, (state, action) => {
       state.status = LoadingStatus.Pending;
       state.query = action.meta.arg;
+      state.score = 0;
+      state.guess = undefined;
+      state.previousCard = undefined;
+      state.card = undefined;
     });
 
     builder.addCase(startGame.fulfilled, (state) => {


### PR DESCRIPTION
Since routing might give you a way to finally start a new game while an existing game is in progress, let's update the startGame task to reset the game state.