### PR TITLE
Lofi settings screen navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,9 +4,11 @@ import ThemeButton from "./components/ThemeButton.vue";
 import ViewSettingsButton from "./components/ViewSettingsButton.vue";
 import { useAppSelector } from "./store/hooks";
 import { RouterView } from "vue-router";
+import SettingsScreen from "./pages/SettingsScreen.vue";
 
 const theme = useAppSelector((state) => state.config.theme);
 const currentYear = ref(new Date().getFullYear());
+const viewConfigScreen = useAppSelector((state) => state.config.viewConfigScreen);
 </script>
 
 <template>
@@ -31,7 +33,8 @@ const currentYear = ref(new Date().getFullYear());
     </header>
 
     <main>
-      <RouterView />
+      <SettingsScreen v-show="viewConfigScreen" />
+      <RouterView v-show="!viewConfigScreen" />
     </main>
 
     <footer>

--- a/src/components/ViewSettingsButton.vue
+++ b/src/components/ViewSettingsButton.vue
@@ -1,36 +1,29 @@
 <script setup lang="ts">
-import { computed } from "vue";
-import { useRoute } from "vue-router";
 import CogOutlineSvg from "./Svg/CogOutlineSvg.vue";
 import CogSolidSvg from "./Svg/CogSolidSvg.vue";
-import router from "../router";
+import { setViewConfigScreen, useAppDispatch, useAppSelector } from "../store";
 
-const route = useRoute();
+const dispatch = useAppDispatch();
+const isViewingSettings = useAppSelector((state) => state.config.viewConfigScreen);
 
-const isViewingSettings = computed(() => route.path === "/settings");
-
-const link = computed(() => {
+const click = () => {
   if (isViewingSettings.value) {
-    // if we're currently on the settings page and the settings
-    // link is pressed, then we want to go back to whatever the
-    // previous page was. And if /settings is the first page
-    // the user lands on, we go to /
-    return router.options.history.state.back?.toString() ?? "/";
+    dispatch(setViewConfigScreen(false));
+  } else {
+    dispatch(setViewConfigScreen(true));
   }
-
-  return "/settings";
-});
+};
 </script>
 
 <template>
-  <RouterLink :to="link" class="settings btn-icon">
+  <button type="button" class="settings btn-icon" @click="click">
     <div class="icon" aria-hidden="true">
       <CogOutlineSvg v-if="isViewingSettings" />
       <CogSolidSvg v-else />
     </div>
     <div class="vh" v-if="isViewingSettings">Close settings</div>
     <div class="vh" v-else>Open settings</div>
-  </RouterLink>
+  </button>
 </template>
 
 <style scoped lang="scss">

--- a/src/components/ViewSettingsButton.vue
+++ b/src/components/ViewSettingsButton.vue
@@ -7,11 +7,7 @@ const dispatch = useAppDispatch();
 const isViewingSettings = useAppSelector((state) => state.config.viewConfigScreen);
 
 const click = () => {
-  if (isViewingSettings.value) {
-    dispatch(setViewConfigScreen(false));
-  } else {
-    dispatch(setViewConfigScreen(true));
-  }
+  dispatch(setViewConfigScreen(!isViewingSettings.value));
 };
 </script>
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,5 @@
 import { createWebHistory, createRouter } from "vue-router";
 
-import SettingsScreen from "./pages/SettingsScreen.vue";
 import NotFound from "./pages/NotFound.vue";
 import FormatGame from "./pages/FormatGame.vue";
 import PickModeScreen from "./pages/PickModeScreen.vue";
@@ -9,7 +8,6 @@ import CustomGameSetup from "./pages/CustomGameSetup.vue";
 
 const routes = [
   { path: "/", component: PickModeScreen },
-  { path: "/settings", component: SettingsScreen },
   {
     path: "/game/",
     children: [

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -20,8 +20,13 @@ export const configSlice = createSlice({
     setAutocomplete(state, action: PayloadAction<boolean>) {
       state.autocomplete = action.payload;
     },
+    setViewConfigScreen(state, action: PayloadAction<boolean>) {
+      state.viewConfigScreen = action.payload;
+    },
   },
 });
+
+export const { setViewConfigScreen } = configSlice.actions;
 
 export const loadConfig = createAction(configSlice.actions.loadConfig.type, () => {
   const theme = localStorage.getItem(StorageKey.Theme) ?? Theme.Dark;


### PR DESCRIPTION
Right now in art game, visiting settings will reset your game state completely. That's not preferable!

Rather than make it a screen we navigate to, it's now just a screen that shows or hides. There's no more `/settings` link.

This essentially partially reverts #104, going back to a version of the lo-fi tech we had before, only on the settings screen. The rest of the routing stuff is fine and good.

Fixes #106 