### PR TITLE
Max custom query length

### DIFF
--- a/src/pages/CustomGameSetup.vue
+++ b/src/pages/CustomGameSetup.vue
@@ -85,6 +85,7 @@ const onSubmit = async () => {
 
     <section class="search">
       <div class="inputs">
+        <div class="input-field">
           <label class="vh" for="custom-query">Custom Scryfall Query</label>
           <input
             v-model="query"
@@ -96,6 +97,10 @@ const onSubmit = async () => {
             :maxlength="MAX_QUERY_LENGTH"
             :disabled="disabled"
           />
+          <div class="max-length" :class="{ visible: query.length > MAX_QUERY_LENGTH - 200 }">
+            {{ query.length }} / {{ MAX_QUERY_LENGTH }}
+          </div>
+        </div>
         <button type="submit" class="btn btn-large" :disabled="disabled || query.length === 0">
           Start
         </button>
@@ -207,12 +212,27 @@ hr {
 .search {
   .inputs {
     display: flex;
+    align-items: flex-start;
     gap: 12px;
     width: 100%;
   }
 
-  input {
+  .input-field {
     flex: 1;
+    display: flex;
+    flex-flow: column;
+  }
+
+  .max-length {
+    font-size: 80%;
+    opacity: 0.8;
+    margin-top: 4px;
+    font-style: italic;
+    text-align: right;
+
+    &:not(.visible) {
+      visibility: hidden;
+    }
   }
 }
 

--- a/src/pages/CustomGameSetup.vue
+++ b/src/pages/CustomGameSetup.vue
@@ -11,6 +11,17 @@ import LoadingHammer from "../components/LoadingHammer.vue";
 const query = ref("");
 const status = ref(LoadingStatus.Idle);
 
+/**
+ * The maximum length of a custom game query.
+ *
+ * This accounts for:
+ * - The 1000 character limit on the `/cards/search?q=` parameter.
+ * - ~100 characters for compatibility or quality criteria.
+ * - ~100 characters for additional bits and pieces like an included or excluded oracle_id.
+ * - Some fuzziness for some characters being URL-encoded.
+ */
+const MAX_QUERY_LENGTH = 800;
+
 // Filters
 const excludeBadArt = ref(true);
 const excludeExtras = ref(true);
@@ -74,16 +85,17 @@ const onSubmit = async () => {
 
     <section class="search">
       <div class="inputs">
-        <label class="vh" for="custom-query">Custom Scryfall Query</label>
-        <input
-          v-model="query"
-          id="custom-query"
-          class="input-large"
-          type="text"
-          placeholder="set:dom type:creature"
-          required
-          :disabled="disabled"
-        />
+          <label class="vh" for="custom-query">Custom Scryfall Query</label>
+          <input
+            v-model="query"
+            id="custom-query"
+            class="input-large"
+            type="text"
+            placeholder="set:dom type:creature"
+            required
+            :maxlength="MAX_QUERY_LENGTH"
+            :disabled="disabled"
+          />
         <button type="submit" class="btn btn-large" :disabled="disabled || query.length === 0">
           Start
         </button>

--- a/src/pages/CustomGameSetup.vue
+++ b/src/pages/CustomGameSetup.vue
@@ -22,6 +22,10 @@ const status = ref(LoadingStatus.Idle);
  */
 const MAX_QUERY_LENGTH = 800;
 
+const showQueryLengthHint = computed(() => {
+  return query.value.length >= MAX_QUERY_LENGTH * 0.75;
+});
+
 // Filters
 const excludeBadArt = ref(true);
 const excludeExtras = ref(true);
@@ -97,7 +101,7 @@ const onSubmit = async () => {
             :maxlength="MAX_QUERY_LENGTH"
             :disabled="disabled"
           />
-          <div class="max-length" :class="{ visible: query.length > MAX_QUERY_LENGTH - 200 }">
+          <div class="max-length" v-if="showQueryLengthHint">
             {{ query.length }} / {{ MAX_QUERY_LENGTH }}
           </div>
         </div>
@@ -229,10 +233,6 @@ hr {
     margin-top: 4px;
     font-style: italic;
     text-align: right;
-
-    &:not(.visible) {
-      visibility: hidden;
-    }
   }
 }
 


### PR DESCRIPTION
Custom queries are currently of unlimited length, but per #108, the maximum length we can actually use is below 1,000 characters. In fact, budgeting for some bits here and there, the max length you can safely put into a custom query is around 800 characters.

This introduces that max length, plus a thingy that starts counting your characters once you cross the threshold into using 75% of the max length or more.

Fixes #108

![Screenshot 2025-04-28 012552](https://github.com/user-attachments/assets/0e940a7e-ef63-4142-9703-0fcc47c816c8)
![Screenshot 2025-04-28 012601](https://github.com/user-attachments/assets/ec4da576-99a1-4d8e-a7a8-b1fc83ba0868)
![Screenshot 2025-04-28 012647](https://github.com/user-attachments/assets/b7fb3dc9-2e7a-4972-9de1-d24154f073d0)
