### PR TITLE
Remove unneeded keypresses

### DIFF
--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -55,9 +55,7 @@ const submitGuess = (guess: string) => {
 
     <p class="error-loading" v-if="nextCardStatus === LoadingStatus.Failed">
       There was an error loading the next card. Check your internet connection and
-      <button type="button" class="retry link" @click.prevent="retry" @keypress.enter="retry">
-        retry</button
-      >.
+      <button type="button" class="retry link" @click.prevent="retry">retry</button>.
     </p>
 
     <p>

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -66,7 +66,6 @@ const submitGuess = (guess: string) => {
         class="skip link"
         :disabled="nextCardStatus === LoadingStatus.Pending"
         @click.prevent="skip"
-        @keypress.enter="skip"
       >
         skip</button
       >)

--- a/src/components/ThemeButton.vue
+++ b/src/components/ThemeButton.vue
@@ -17,7 +17,6 @@ const toggle = () => {
     type="button"
     :class="{ light: theme === Theme.Light, dark: theme === Theme.Dark }"
     @click="toggle"
-    @keypress.enter="toggle"
   >
     <div class="icon sun" aria-hidden="true">
       <SunOutlineSvg />


### PR DESCRIPTION
There are several buttons in the code base with click handler and `@keypress.enter` handlers. HOWEVER, when you press enter while focussed on any of these elements, it triggers both the click handler and the keypress handler, effectively doubling the action.

For the Theme button, it made it appear like it didn't work (because it was very quickly turning the settings pane on and off again).

For the skip button, it didn't have a noticeable effect, but it was calling the skip action twice.

For the retry button, you could see it load 2 cards instead of just one.

This PR removes the extraneous keypress handlers.